### PR TITLE
Rename functions to be namespaced, remove get_event_by_id()

### DIFF
--- a/demo.c
+++ b/demo.c
@@ -28,7 +28,7 @@ bool printAndErrorE(event_queue* q, branch_event* e){
 
 void removeEPrintF(event_queue* q, branch_event* e){
 	printf("F");
-	remove_event(q, e);
+	evq_remove(q, e->id);
 }
 
 bool printData(event_queue* q, branch_event* e){
@@ -38,53 +38,53 @@ bool printData(event_queue* q, branch_event* e){
 
 int main(int argc, char const *argv[]){
 	//First, initialize an empty queue
-	event_queue* q = init_evq();
+	event_queue* q = evq_init();
 
 	//Most basic way to add a function
-	add_event(q, printA, NULL, NULL);
+	evq_add(q, printA, NULL, NULL);
 
 	//Save the event_id to delete later
-	event_id id = add_event(q, printB, NULL, NULL);
+	event_id id = evq_add(q, printB, NULL, NULL);
 
 	//If function returns true or false, you can also add an false handler
-	add_event(q, printAndSometimesErrorC, errorPrintD, NULL);
+	evq_add(q, printAndSometimesErrorC, errorPrintD, NULL);
 
 	int i = 0;
 	while(i<25){
-		//Repetedly call next() on your queue to keep advancing exection
-		next(q);
+		//Repetedly call evq_next() on your queue to keep advancing exection
+		evq_next(q);
 		i++;
 	}
 	printf("\n");
 
 	//Remove an event with its id
-	remove_id(q, id);
+	evq_remove(q, id);
 
 	//Look! No B
 	i=0;
 	while(i<25){
-		next(q);
+		evq_next(q);
 		i++;
 	}
 	printf("\n");
 
 	//Events can remove themselves during execution
-	add_event(q, printAndErrorE, removeEPrintF, NULL);
+	evq_add(q, printAndErrorE, removeEPrintF, NULL);
 
 	//EF should be printed once then never again
 	i=0;
 	while(i<25){
-		next(q);
+		evq_next(q);
 		i++;
 	}
 	printf("\n");
 
 	//Events can also be created with specific data relevent to that instance of an event
 	char* s = " hello world! ";
-	add_event(q, printData, NULL, (void*)s);
+	evq_add(q, printData, NULL, (void*)s);
 	i=0;
 	while(i<5){
-		next(q);
+		evq_next(q);
 		i++;
 	}
 	printf("\n");

--- a/evq.c
+++ b/evq.c
@@ -1,6 +1,6 @@
 #include "evq.h"
 
-event_queue* init_evq(){
+event_queue* evq_init(){
 	event_queue* evq = (event_queue*)malloc(sizeof(event_queue));
 	evq->start = NULL;
 	evq->next_id = 0;
@@ -8,7 +8,7 @@ event_queue* init_evq(){
 	return evq;
 }
 
-event_id add_event(event_queue* evq, branch_func f, error_func err_f, void* data){
+event_id evq_add(event_queue* evq, branch_func f, error_func err_f, void* data){
 	if(f == NULL || evq == NULL){
 		return -1;
 	}
@@ -23,7 +23,7 @@ event_id add_event(event_queue* evq, branch_func f, error_func err_f, void* data
 	return event->id;
 }
 
-void remove_id(event_queue* evq, event_id id){
+void evq_remove(event_queue* evq, event_id id){
 	if(evq->start->id == id){
 		branch_event* t = evq->start->next;
 		free(evq->start);
@@ -44,22 +44,7 @@ void remove_id(event_queue* evq, event_id id){
 	free(cur);
 }
 
-void remove_event(event_queue* evq, branch_event* evt){
-	remove_id(evq, evt->id);
-}
-
-branch_event* get_event_by_id(event_queue* evq, event_id id){
-	branch_event* cur = evq->start;
-	while(cur->id != id){
-		cur = cur->next;
-		if(cur->next == NULL){
-			break;
-		}
-	}
-	return cur;
-}
-
-void next(event_queue* evq){
+void evq_next(event_queue* evq){
 	evq->exec = true;
 	if(evq->current == NULL){
 		evq->current = evq->start;
@@ -76,7 +61,7 @@ void next(event_queue* evq){
 		if(evq->current->err_f != NULL){
 			evq->current->err_f(evq, evq->current);
 		}
-	
-	evq->current = next_event; 
+
+	evq->current = next_event;
 	evq->exec = false;
 }

--- a/evq.h
+++ b/evq.h
@@ -1,8 +1,8 @@
-#ifndef _EVQ_H_
-#define _EVQ_H_
+#ifndef EVQ_H
+#define EVQ_H
 
-#include <stdbool.h>
 #include <stdlib.h>
+#include <stdbool.h>
 
 typedef struct branch_event branch_event;
 typedef struct event_queue event_queue;
@@ -25,11 +25,9 @@ struct event_queue{
 	bool exec;
 };
 
-event_queue* init_evq(void);
-event_id add_event(event_queue* evq, branch_func f, error_func err_f, void* data);
-void remove_id(event_queue* evq, event_id id);
-void remove_event(event_queue* evq, branch_event* evt);
-branch_event* get_event_by_id(event_queue* evq, event_id id);
-void next(event_queue* evq);
+event_queue* evq_init(void);
+event_id evq_add(event_queue* evq, branch_func f, error_func err_f, void* data);
+void evq_remove(event_queue* evq, event_id id);
+void evq_next(event_queue* evq);
 
 #endif


### PR DESCRIPTION
Functions should be prefixed with `evq_` to prevent naming conflicts.